### PR TITLE
feat: Add PogRust

### DIFF
--- a/.github/workflows/dev-pogrust-build.yml
+++ b/.github/workflows/dev-pogrust-build.yml
@@ -1,0 +1,37 @@
+name: Build and Test PogRust Development Image
+
+on:
+  schedule:
+    - cron: "20 04 * * *"
+  push:
+    branches: ["dev"]
+    paths: ["pogrust/**", ".github/workflows/dev-pogrust-build.yml"]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["dev"]
+    paths: ["pogrust/**", ".github/workflows/dev-pogrust-build.yml"]
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push-pogrust
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: ./pogrust

--- a/.github/workflows/main-pogrust-build-publish.yml
+++ b/.github/workflows/main-pogrust-build-publish.yml
@@ -1,0 +1,84 @@
+name: Build and Publish PogRust Image
+
+on:
+  schedule:
+    - cron: "20 04 * * *"
+  push:
+    branches: ["main"]
+    paths: ["pogrust/**", ".github/workflows/main-pogrust-build-publish.yml"]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["main"]
+    paths: ["pogrust/**", ".github/workflows/main-pogrust-build-publish.yml"]
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        with:
+          cosign-release: "v2.1.1"
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta-pogrust
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/pogrust
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push-pogrust
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: ./pogrust
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-pogrust.outputs.tags }}
+          labels: ${{ steps.meta-pogrust.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          echo "${{ steps.meta-pogrust.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-pogrust.outputs.digest }}

--- a/pogrust/Dockerfile
+++ b/pogrust/Dockerfile
@@ -1,0 +1,36 @@
+# Dockerfile for PogRust, a Rust development environment from the Pogger Project
+# Description: This container is meant to be used as a Visual Studio Code devcontainer but can be used as a standalone container
+# Version: 1.0.0
+# Date: 2023/09/14
+# Author: Dexxiez
+# Usage: docker build -t pogrust . (or google it)
+
+# BIS - Best Image Size (obviously that's what it stands for)
+FROM alpine:3.18
+
+# Add the bare essentials
+RUN apk add --no-cache \
+    bash \
+    wget \
+    curl \
+    git \
+    rustup \
+    && rm -rf /var/cache/apk/*
+
+# Add a user for development
+RUN adduser -D -u 1000 -s /bin/bash dev
+
+USER dev
+
+RUN rustup-init --profile default -y
+
+RUN echo 'source $HOME/.cargo/env' >> ~/.bashrc
+RUN echo "" >> ~/.bashrc
+
+# Make the shell feel more like home
+RUN echo 'parse_git_branch() { git branch 2> /dev/null | sed -e "/^[^*]/d" -e "s/* \(.*\)/ (\1)/"; }' >> ~/.bashrc
+RUN echo 'export PS1="\[\033[01;32m\]\u\[\e[38;5;225m\]@\[\e[38;5;199m\]PogRust\[\033[00m\]:\[\033[01;34m\]\w\[\033[01;31m\]\$(parse_git_branch)\[\033[00m\]\$ "' >> ~/.bashrc
+
+CMD [ "sleep", "infinity" ]
+
+# End of Dockerfile if you hadn't noticed


### PR DESCRIPTION
This commit adds two new workflow files for building and testing PogRust development image (`dev-pogrust-build.yml`) and publishing PogRust image (`main-pogrust-build-publish.yml`). The workflows are triggered on a schedule and for specific branches and paths. The Docker images are built using Docker buildx and pushed to a Docker registry. The workflows also include steps for logging into the registry, extracting metadata, and signing the published Docker image. Additionally, a Dockerfile for PogRust is included, which sets up a Rust development environment and adds a user for development purposes.